### PR TITLE
Remove empty label tag

### DIFF
--- a/src/js/BzmDatePickerMod.js
+++ b/src/js/BzmDatePickerMod.js
@@ -660,6 +660,10 @@ function bzmDatePicker ($log, $document, $filter) {
             if (attrs.label) {
                 var label= element.find ('label');
                 label.html (attrs.label);
+            } else {
+                // if the label is not set, delete the label tag from template
+                var label = element.find('label');
+                label.remove();
             }
 
             // Monitor any changes on start/stop dates.


### PR DESCRIPTION
Even if a label is not provided, the template still contains the label tag. This empty label tag takes some space and cause alignment issues.
